### PR TITLE
Fixed weirdness during modeline filetype usage

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -72,6 +72,19 @@ func! rainbow_parentheses#toggle()
 	endif
 endfunc
 
+func! rainbow_parentheses#toggleall()
+	if !exists('s:active')
+		cal rainbow_parentheses#load(0)
+    cal rainbow_parentheses#load(1)
+    cal rainbow_parentheses#load(2)
+	endif
+	if exists('s:active') && s:active
+		cal rainbow_parentheses#clear()
+	else
+		cal rainbow_parentheses#activate()
+	endif
+endfunc
+
 func! s:cluster()
 	let levels = ''
 	for each in range(1, s:max)

--- a/plugin/rainbow_parentheses.vim
+++ b/plugin/rainbow_parentheses.vim
@@ -5,6 +5,7 @@
 "  GetLatestVimScripts: 3772 1 :AutoInstall: rainbow_parentheses.zip
 
 com! RainbowParenthesesToggle       cal rainbow_parentheses#toggle()
+com! RainbowParenthesesToggleAll    cal rainbow_parentheses#toggleall()
 com! RainbowParenthesesLoadRound    cal rainbow_parentheses#load(0)
 com! RainbowParenthesesLoadSquare   cal rainbow_parentheses#load(1)
 com! RainbowParenthesesLoadBraces   cal rainbow_parentheses#load(2)


### PR DESCRIPTION
VimEnter Toggle works, SyntaxLoadFoo doesn't. Single command that does all seems to fix it.
