### PR TITLE
Added RainbowParenthesesActivate command into plugin file

### DIFF
--- a/plugin/rainbow_parentheses.vim
+++ b/plugin/rainbow_parentheses.vim
@@ -6,6 +6,7 @@
 
 com! RainbowParenthesesToggle       cal rainbow_parentheses#toggle()
 com! RainbowParenthesesToggleAll    cal rainbow_parentheses#toggleall()
+com! RainbowParenthesesActivate     cal rainbow_parentheses#activate()
 com! RainbowParenthesesLoadRound    cal rainbow_parentheses#load(0)
 com! RainbowParenthesesLoadSquare   cal rainbow_parentheses#load(1)
 com! RainbowParenthesesLoadBraces   cal rainbow_parentheses#load(2)


### PR DESCRIPTION
I would suggest adding RainbowParenthesesActivate. It's useful when you set filetype autocmd like...

``` vim
autocmd Filetype scheme RainbowParenthesesActivate
```

It's better than RainbowParenthesesToggle action because it doesn't cause unintended "toggle off" when opening new buffer with :split. 
