### PR TITLE
Add option to bold parentheses, defaulting to on

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -26,6 +26,7 @@ let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs
 let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 16])
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]
+let s:bold = exists('g:bold_parentheses') ? g:bold_parentheses : 1
 
 func! s:extend()
 	if s:max > len(s:pairs)
@@ -39,8 +40,9 @@ cal s:extend()
 
 func! rainbow_parentheses#activate()
 	let [id, s:active] = [1, 1]
+	let bold = s:bold ? ' cterm=bold gui=bold' : ''
 	for [ctermfg, guifg] in s:pairs
-		exe 'hi default level'.id.'c ctermfg='.ctermfg.' guifg='.guifg
+		exe 'hi default level'.id.'c ctermfg='.ctermfg.' guifg='.guifg.bold
 		let id += 1
 	endfor
 endfunc

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,10 @@ let g:rbpt_max = 16
 let g:rbpt_loadcmd_toggle = 0
 ```
 
+```vim
+let g:bold_parentheses = 0      " Default on
+```
+
 ### Commands:
 
 ```vim


### PR DESCRIPTION
Bolding parentheses makes it easier to see and distinguish between the rainbow colors.

(Yes, I know you have another open pull request from a year ago on adding bolding. The big difference is that while that fork has diverged and removed all gui options, my version adds a bold option for gui as well as for cterm.)
