### PR TITLE
adds g:rbpt_disabled_colors

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -23,7 +23,14 @@ let s:pairs = [
 	\ ['red',         'firebrick3'],
 	\ ]
 let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs
-let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 16])
+if exists('g:rbpt_disabled_colors')
+  let s:color_filter = 'index(g:rbpt_disabled_colors, v:val[0]) < 0'
+  let s:default_max = 16 - len(g:rbpt_disabled_colors)
+  let s:pairs = filter(copy(s:pairs), s:color_filter)
+else
+  let s:default_max = 16
+endif
+let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), s:default_max])
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,10 @@ let g:rbpt_max = 16
 let g:rbpt_loadcmd_toggle = 0
 ```
 
+```vim
+let g:rbpt_disabled_colors = ['black', 'brown']
+```
+
 ### Commands:
 
 ```vim


### PR DESCRIPTION
saves people from forking to remove colors from default pairs.

https://github.com/kien/rainbow_parentheses.vim/pull/9
