### PR TITLE
Read the color pairs in top to bottom order, instead of prior complicated manner

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -14,7 +14,6 @@ let s:pairs = [
 	\ ['darkmagenta', 'DarkOrchid3'],
 	\ ['brown',       'firebrick3'],
 	\ ['gray',        'RoyalBlue3'],
-	\ ['black',       'SeaGreen3'],
 	\ ['darkmagenta', 'DarkOrchid3'],
 	\ ['Darkblue',    'firebrick3'],
 	\ ['darkgreen',   'RoyalBlue3'],

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -5,20 +5,20 @@
 "==============================================================================
 
 let s:pairs = [
+	\ ['red',         'RoyalBlue3'],
+	\ ['brown',       'SeaGreen3'],
+	\ ['blue',        'DarkOrchid3'],
+	\ ['gray',        'firebrick3'],
+	\ ['green',       'RoyalBlue3'],
+	\ ['magenta',     'SeaGreen3'],
+	\ ['cyan',        'DarkOrchid3'],
+	\ ['darkred',     'firebrick3'],
 	\ ['brown',       'RoyalBlue3'],
-	\ ['Darkblue',    'SeaGreen3'],
-	\ ['darkgray',    'DarkOrchid3'],
-	\ ['darkgreen',   'firebrick3'],
-	\ ['darkcyan',    'RoyalBlue3'],
-	\ ['darkred',     'SeaGreen3'],
-	\ ['darkmagenta', 'DarkOrchid3'],
-	\ ['brown',       'firebrick3'],
-	\ ['gray',        'RoyalBlue3'],
-	\ ['darkmagenta', 'DarkOrchid3'],
-	\ ['Darkblue',    'firebrick3'],
+	\ ['darkblue',    'DarkOrchid3'],
+	\ ['gray',        'firebrick3'],
 	\ ['darkgreen',   'RoyalBlue3'],
-	\ ['darkcyan',    'SeaGreen3'],
-	\ ['darkred',     'DarkOrchid3'],
+	\ ['darkmagenta', 'SeaGreen3'],
+	\ ['darkcyan',    'DarkOrchid3'],
 	\ ['red',         'firebrick3'],
 	\ ]
 let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -22,7 +22,7 @@ let s:pairs = [
 	\ ['red',         'firebrick3'],
 	\ ]
 let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs
-let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 16])
+let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 15])
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]
 

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -26,6 +26,7 @@ let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs
 let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 16])
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]
+let s:bold = exists('g:bold_parentheses') ? g:bold_parentheses : 1
 
 func! s:extend()
 	if s:max > len(s:pairs)
@@ -39,8 +40,9 @@ cal s:extend()
 
 func! rainbow_parentheses#activate()
 	let [id, s:active] = [1, 1]
+	let bold = s:bold ? ' cterm=bold gui=bold' : ''
 	for [ctermfg, guifg] in s:pairs
-		exe 'hi default level'.id.'c ctermfg='.ctermfg.' guifg='.guifg
+		exe 'hi default level'.id.'c ctermfg='.ctermfg.' guifg='.guifg.bold
 		let id += 1
 	endfor
 endfunc

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -89,7 +89,7 @@ func! rainbow_parentheses#load(...)
 	for each in range(1, s:max)
 		let region = 'level'. each .(b:loaded[a:1] ? '' : 'none')
 		let grp = b:loaded[a:1] ? 'level'.each.'c' : 'Normal'
-		let cmd = 'sy region %s matchgroup=%s start=/%s/ end=/%s/ contains=TOP,%s,NoInParens'
+		let cmd = 'sy region %s matchgroup=%s start=/%s/ end=/%s/ contains=TOP,%s,NoInParens fold'
 		exe printf(cmd, region, grp, type[0], type[1], join(alllvls, ','))
 		cal remove(alllvls, 0)
 	endfor

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -4,7 +4,7 @@
 "               2011-10-12: Use less code.  Leave room for deeper levels.
 "==============================================================================
 
-let s:pairs = [
+let s:rpairs= [
 	\ ['brown',       'RoyalBlue3'],
 	\ ['Darkblue',    'SeaGreen3'],
 	\ ['darkgray',    'DarkOrchid3'],
@@ -22,7 +22,7 @@ let s:pairs = [
 	\ ['darkred',     'DarkOrchid3'],
 	\ ['red',         'firebrick3'],
 	\ ]
-let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs
+let s:pairs = exists('g:rbpt_colorpairs') ? reverse(g:rbpt_colorpairs) : reverse(s:rpairs)
 let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 16])
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # Better Rainbow Parentheses
 
+Forked from https://github.com/kien/rainbow_parentheses.vim since it now appears
+to be unmaintained.
+
 ### Options:
 
 ```vim
@@ -13,7 +16,6 @@ let g:rbpt_colorpairs = [
     \ ['darkmagenta', 'DarkOrchid3'],
     \ ['brown',       'firebrick3'],
     \ ['gray',        'RoyalBlue3'],
-    \ ['black',       'SeaGreen3'],
     \ ['darkmagenta', 'DarkOrchid3'],
     \ ['Darkblue',    'firebrick3'],
     \ ['darkgreen',   'RoyalBlue3'],
@@ -24,7 +26,7 @@ let g:rbpt_colorpairs = [
 ```
 
 ```vim
-let g:rbpt_max = 16
+let g:rbpt_max = 15
 ```
 
 ```vim

--- a/readme.md
+++ b/readme.md
@@ -10,22 +10,22 @@ list, the next-outermost with the second-last colour, etc. The first element of
 each entry is the terminal colour, the second element is the GUI (gvim) colour.
 ```vim
 let g:rbpt_colorpairs = [
-	\ ['red',         'RoyalBlue3'],
-	\ ['brown',       'SeaGreen3'],
-	\ ['blue',        'DarkOrchid3'],
-	\ ['gray',        'firebrick3'],
-	\ ['green',       'RoyalBlue3'],
-	\ ['magenta',     'SeaGreen3'],
-	\ ['cyan',        'DarkOrchid3'],
-	\ ['darkred',     'firebrick3'],
-	\ ['brown',       'RoyalBlue3'],
-	\ ['darkblue',    'DarkOrchid3'],
-	\ ['gray',        'firebrick3'],
-	\ ['darkgreen',   'RoyalBlue3'],
-	\ ['darkmagenta', 'SeaGreen3'],
-	\ ['darkcyan',    'DarkOrchid3'],
-	\ ['red',         'firebrick3'],
-        \ ]
+    \ ['red',         'RoyalBlue3'],
+    \ ['brown',       'SeaGreen3'],
+    \ ['blue',        'DarkOrchid3'],
+    \ ['gray',        'firebrick3'],
+    \ ['green',       'RoyalBlue3'],
+    \ ['magenta',     'SeaGreen3'],
+    \ ['cyan',        'DarkOrchid3'],
+    \ ['darkred',     'firebrick3'],
+    \ ['brown',       'RoyalBlue3'],
+    \ ['darkblue',    'DarkOrchid3'],
+    \ ['gray',        'firebrick3'],
+    \ ['darkgreen',   'RoyalBlue3'],
+    \ ['darkmagenta', 'SeaGreen3'],
+    \ ['darkcyan',    'DarkOrchid3'],
+    \ ['red',         'firebrick3'],
+    \ ]
 ```
 
 How deep to colour (repeating the colour list if necessary) before giving up;

--- a/readme.md
+++ b/readme.md
@@ -1,30 +1,35 @@
 # Better Rainbow Parentheses
 
-Forked from https://github.com/kien/rainbow_parentheses.vim since it now appears
-to be unmaintained.
+Forked from https://github.com/kien/rainbow_parentheses.vim since that now
+appears to be unmaintained.
 
 ### Options:
 
+The colours used; the outermost pair is coloured with the last colour in the
+list, the next-outermost with the second-last colour, etc. The first element of
+each entry is the terminal colour, the second element is the GUI (gvim) colour.
 ```vim
 let g:rbpt_colorpairs = [
-    \ ['brown',       'RoyalBlue3'],
-    \ ['Darkblue',    'SeaGreen3'],
-    \ ['darkgray',    'DarkOrchid3'],
-    \ ['darkgreen',   'firebrick3'],
-    \ ['darkcyan',    'RoyalBlue3'],
-    \ ['darkred',     'SeaGreen3'],
-    \ ['darkmagenta', 'DarkOrchid3'],
-    \ ['brown',       'firebrick3'],
-    \ ['gray',        'RoyalBlue3'],
-    \ ['darkmagenta', 'DarkOrchid3'],
-    \ ['Darkblue',    'firebrick3'],
-    \ ['darkgreen',   'RoyalBlue3'],
-    \ ['darkcyan',    'SeaGreen3'],
-    \ ['darkred',     'DarkOrchid3'],
-    \ ['red',         'firebrick3'],
-    \ ]
+	\ ['red',         'RoyalBlue3'],
+	\ ['brown',       'SeaGreen3'],
+	\ ['blue',        'DarkOrchid3'],
+	\ ['gray',        'firebrick3'],
+	\ ['green',       'RoyalBlue3'],
+	\ ['magenta',     'SeaGreen3'],
+	\ ['cyan',        'DarkOrchid3'],
+	\ ['darkred',     'firebrick3'],
+	\ ['brown',       'RoyalBlue3'],
+	\ ['darkblue',    'DarkOrchid3'],
+	\ ['gray',        'firebrick3'],
+	\ ['darkgreen',   'RoyalBlue3'],
+	\ ['darkmagenta', 'SeaGreen3'],
+	\ ['darkcyan',    'DarkOrchid3'],
+	\ ['red',         'firebrick3'],
+        \ ]
 ```
 
+How deep to colour (repeating the colour list if necessary) before giving up;
+limited for performance reasons.
 ```vim
 let g:rbpt_max = 15
 ```
@@ -33,8 +38,9 @@ let g:rbpt_max = 15
 let g:rbpt_loadcmd_toggle = 0
 ```
 
+Also bold parenthese to make the colours stand out more.
 ```vim
-let g:bold_parentheses = 0      " Default on
+let g:bold_parentheses = 1      " Default on
 ```
 
 ### Commands:

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,10 @@ let g:rbpt_max = 16
 let g:rbpt_loadcmd_toggle = 0
 ```
 
+```vim
+let g:bold_parentheses = 0      " Default on
+```
+
 ### Commands:
 
 ```vim


### PR DESCRIPTION
![samplecolorsetup](https://cloud.githubusercontent.com/assets/271309/4828633/8ea59d30-5f81-11e4-97f4-8e21a15b667a.png)
![oldbehaviorvisualization](https://cloud.githubusercontent.com/assets/271309/4828637/91ba5d62-5f81-11e4-8b89-23fa6e30fd02.png)
![newbehaviorvisualization](https://cloud.githubusercontent.com/assets/271309/4828639/948c8588-5f81-11e4-9a65-0c80b92e238c.png)

This makes it so both g:rbt_colorpairs in the user .vimrc and s:pairs in
the autoload are easier to understand, with the highest level scope
being the first entry, the 2nd level scope being the second entry, etc.

The behavior this replaces is complicated and probably unintended, being a mix of truncation from max, extension from max, and using the list backwards. Note, I did not effect the s:max code, just the color order.
