### PR TITLE
Disable in Vim compatible mode. Add a global to detect if loaded.

### DIFF
--- a/plugin/rainbow_parentheses.vim
+++ b/plugin/rainbow_parentheses.vim
@@ -4,6 +4,14 @@
 "==============================================================================
 "  GetLatestVimScripts: 3772 1 :AutoInstall: rainbow_parentheses.zip
 
+" Exit quickly when:
+" - this plugin was already loaded (or disabled)
+" - when 'compatible' is set
+if exists("g:loaded_rainbow_parentheses") || &cp
+  finish
+endif
+let g:loaded_rainbow_parentheses = 1
+
 com! RainbowParenthesesToggle       cal rainbow_parentheses#toggle()
 com! RainbowParenthesesToggleAll    cal rainbow_parentheses#toggleall()
 com! RainbowParenthesesActivate     cal rainbow_parentheses#activate()


### PR DESCRIPTION
1. Disable this plugin if 'compatible' is set.
2. Add a global to detect the presence of this plugin.

I use `g:loaded_rainbow_parentheses` in `.vimrc` like so:
```Vim
function! SetupPlugins()
    if exists('g:loaded_rainbow_parentheses')
        echom "Configuring Rainbow Parentheses..."
        autocmd FileType json,javascript,css,html RainbowParenthesesActivate
        autocmd Syntax javascript RainbowParenthesesLoadRound
        autocmd Syntax json,javascript RainbowParenthesesLoadSquare
        autocmd Syntax json,javascript,css RainbowParenthesesLoadBraces
        autocmd Syntax html RainbowParenthesesLoadChevrons
    endif
endfunction

" Plugins are loaded after Vim has finished processing .vimrc,
" so we test for their existence and configure them on VimEnter.
autocmd VimEnter * call SetupPlugins()
```

This change is consistent with tpope plugins, for example see https://github.com/tpope/vim-fugitive/blob/master/plugin/fugitive.vim#L6